### PR TITLE
fix: Update Slack notification timestamps to use JST

### DIFF
--- a/backend/app/services/slack_service.py
+++ b/backend/app/services/slack_service.py
@@ -1,6 +1,7 @@
 import asyncio
 from datetime import datetime
 from typing import Any
+from zoneinfo import ZoneInfo
 
 import httpx
 
@@ -14,6 +15,11 @@ class SlackService:
     def __init__(self):
         self.webhook_url = settings.slack_webhook_url
         self.timeout = 10.0
+
+    def _get_jst_timestamp(self) -> str:
+        """Get current timestamp in JST (Japan Standard Time)"""
+        jst = ZoneInfo("Asia/Tokyo")
+        return datetime.now(jst).strftime('%Y-%m-%d %H:%M:%S')
 
     async def send_visitor_notification(
         self,
@@ -66,7 +72,7 @@ class SlackService:
                         },
                         {
                             "type": "mrkdwn",
-                            "text": f"*発生時刻:*\n{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"
+                            "text": f"*発生時刻:*\n{self._get_jst_timestamp()}"
                         }
                     ]
                 },
@@ -137,7 +143,7 @@ class SlackService:
                         },
                         {
                             "type": "mrkdwn",
-                            "text": f"*開始時刻:*\n{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"
+                            "text": f"*開始時刻:*\n{self._get_jst_timestamp()}"
                         }
                     ]
                 },
@@ -220,7 +226,7 @@ class SlackService:
                     },
                     {
                         "type": "mrkdwn",
-                        "text": f"*対応時刻:*\n{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"
+                        "text": f"*対応時刻:*\n{self._get_jst_timestamp()}"
                     }
                 ]
             }

--- a/backend/tests/test_slack_service.py
+++ b/backend/tests/test_slack_service.py
@@ -1,0 +1,108 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from app.services.slack_service import SlackService
+from app.models.visitor import VisitorInfo
+
+
+class TestSlackService:
+    """Test cases for SlackService"""
+
+    @pytest.fixture
+    def slack_service(self):
+        """Create SlackService instance for testing"""
+        return SlackService()
+
+    def test_get_jst_timestamp_format(self, slack_service):
+        """Test that JST timestamp returns correct format"""
+        timestamp = slack_service._get_jst_timestamp()
+        
+        # Check format: YYYY-MM-DD HH:MM:SS
+        assert len(timestamp) == 19
+        assert timestamp[4] == '-'
+        assert timestamp[7] == '-'
+        assert timestamp[10] == ' '
+        assert timestamp[13] == ':'
+        assert timestamp[16] == ':'
+
+    def test_get_jst_timestamp_timezone(self, slack_service):
+        """Test that timestamp is in JST timezone"""
+        # Mock current time to a known value
+        fixed_utc_time = datetime(2025, 8, 15, 9, 30, 0)  # 9:30 UTC
+        expected_jst_time = "2025-08-15 18:30:00"  # 18:30 JST (UTC+9)
+        
+        with patch('app.services.slack_service.datetime') as mock_datetime:
+            mock_datetime.now.return_value = fixed_utc_time.replace(tzinfo=ZoneInfo("Asia/Tokyo"))
+            timestamp = slack_service._get_jst_timestamp()
+            assert timestamp == expected_jst_time
+
+    @pytest.mark.asyncio
+    async def test_error_notification_uses_jst(self, slack_service):
+        """Test that error notification uses JST timestamp"""
+        with patch.object(slack_service, '_send_webhook_message', return_value=True) as mock_send:
+            with patch.object(slack_service, '_get_jst_timestamp', return_value="2025-08-15 18:30:00") as mock_jst:
+                
+                result = await slack_service.send_error_notification(
+                    "Test error",
+                    "test-session-id"
+                )
+                
+                assert result is True
+                mock_jst.assert_called_once()
+                
+                # Check that the JST timestamp was used in the message
+                call_args = mock_send.call_args[0][0]
+                error_time_field = call_args['blocks'][1]['fields'][1]['text']
+                assert "2025-08-15 18:30:00" in error_time_field
+
+    @pytest.mark.asyncio
+    async def test_video_call_notification_uses_jst(self, slack_service):
+        """Test that video call notification uses JST timestamp"""
+        visitor_info: VisitorInfo = {
+            'name': 'テスト太郎',
+            'company': 'テスト株式会社'
+        }
+        
+        with patch.object(slack_service, '_send_webhook_message', return_value=True) as mock_send:
+            with patch.object(slack_service, '_get_jst_timestamp', return_value="2025-08-15 18:30:00") as mock_jst:
+                
+                result = await slack_service.send_video_call_notification(
+                    visitor_info,
+                    "https://example.com/room",
+                    "test-room"
+                )
+                
+                assert result is True
+                mock_jst.assert_called_once()
+                
+                # Check that the JST timestamp was used in the message
+                call_args = mock_send.call_args[0][0]
+                start_time_field = call_args['blocks'][1]['fields'][3]['text']
+                assert "2025-08-15 18:30:00" in start_time_field
+
+    @pytest.mark.asyncio
+    async def test_visitor_notification_uses_jst(self, slack_service):
+        """Test that visitor notification uses JST timestamp"""
+        visitor_info: VisitorInfo = {
+            'name': 'テスト太郎',
+            'company': 'テスト株式会社',
+            'visitor_type': 'appointment'
+        }
+        
+        with patch.object(slack_service, '_send_webhook_message', return_value=True) as mock_send:
+            with patch.object(slack_service, '_get_jst_timestamp', return_value="2025-08-15 18:30:00") as mock_jst:
+                
+                result = await slack_service.send_visitor_notification(
+                    visitor_info,
+                    []
+                )
+                
+                assert result is True
+                mock_jst.assert_called_once()
+                
+                # Check that the JST timestamp was used in the message
+                call_args = mock_send.call_args[0][0]
+                response_time_field = call_args['blocks'][1]['fields'][3]['text']
+                assert "2025-08-15 18:30:00" in response_time_field


### PR DESCRIPTION
This PR fixes the Slack notification timestamps to display in JST (Japan Standard Time) instead of the server's local timezone.

## Changes
- Added JST timezone support using Python's built-in zoneinfo
- Created _get_jst_timestamp() helper method for consistent JST timestamps
- Updated all timestamp occurrences in error, video call, and visitor notifications
- Added comprehensive tests for JST timestamp functionality

Resolves #33

🤖 Generated with [Claude Code](https://claude.ai/code)